### PR TITLE
Added an 's' to EmployeeList in Department Model

### DIFF
--- a/BangazonWebApp/BangazonWebApp/Models/Departments.cs
+++ b/BangazonWebApp/BangazonWebApp/Models/Departments.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using BangazonWebApp.Models;
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 
 
@@ -17,7 +18,7 @@ namespace BangazonWebApp.Controllers
         [Required]
         public string Budget { get; set; }
 
-        List<Employees> EmployeeList = new List<Employees>();
+        List<Employees> EmployeesList = new List<Employees>();
 
     }
 


### PR DESCRIPTION
Purpose: 
The 'EmployeeList' at the end of this model needed to say 'EmployeesList'.

How it fits in context of the project:
This change was needed because it was causing build errors when running the project since the Employees table is plural and not singular.

Specific Feature affected:
Departments.cs

How to test (Be thorough!):
1. checkout to my branch lr-deptModelUpdate
2. start BangazonWebApp.sln from the terminal
3. check the ERD (shown in the top left corner of the link below) to make sure the keys are appropriately represented in the model
https://files.slack.com/files-pri/T03F2SDTJ-FD1NF8LKC/image_from_ios.jpg
4. run the program by clicking the green arrow IISExpress button and a browser should appear with a generic webpage